### PR TITLE
Fix issue with encoding when searching for a product.

### DIFF
--- a/connector_magento/components/backend_adapter.py
+++ b/connector_magento/components/backend_adapter.py
@@ -337,7 +337,7 @@ class GenericAdapter(AbstractComponent):
     @staticmethod
     def escape(term):
         if isinstance(term, str):
-            return quote_plus(term)
+            return quote_plus(quote_plus(term))
         return term
 
     def read(self, external_id, attributes=None, storeview=None):


### PR DESCRIPTION
13955

Fixes issue with strings like "CAP_GREEN/CAMO" otherwise the URL is not found from magento routing system.